### PR TITLE
Change setting name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,8 +27,8 @@ The embedded code in the markdown creates a `<script>` tag like this:
 <script src="https://gist.github.com/35c288114e2cd98e1ca4fd875e7749fe.js"></script>
 ```
 
-> #### Set *EditorAllowRenderScriptTags: true*
-> Markdown Monster by default doesn't allow `<script>` tags to be rendered. Embedded Gists use `<script>` tags and so you **have to** enable script embedding by setting the `EditorAllowRenderScriptTags: true` in the Markdown Monster settings. Goto **Tools -> Settings** and find the **EditorAllowRenderScriptTags** key to set.
+> #### Set *AllowRenderScriptTags: true*
+> Markdown Monster by default doesn't allow `<script>` tags to be rendered. Embedded Gists use `<script>` tags and so you **have to** enable script embedding by setting the `AllowRenderScriptTags: true` in the Markdown Monster settings. Goto **Tools -> Settings** and find the **AllowRenderScriptTags** key to set.
 
 ### Configuration
 This addin is still a bit rough in its early release and there's no configuration UI. In order to configure the addin credentials if you want to post non-anonymous Gists you can edit the `PasteCodeAsGistAddin.json` file. To find the file go to **Tools -> Open Configuration Folder** and find **PasteCodeAsGistAddin.json**. Inside of this file you can set your Github username and user token to allow posting Gists under your account name:


### PR DESCRIPTION
I couldn't find a setting called `EditorAllowRenderScriptTags` but there is one called `AllowRenderScriptTags`